### PR TITLE
Fix global state

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,28 +1,32 @@
 'use strict';
 
 var ghGot = require('gh-got');
-var page = 1;
-var ret = [];
 
 function getRepos(user, opts, cb) {
-	var url = 'users/' + user + '/repos?&per_page=100&page=' + page;
+	var page = 1;
+	var ret = [];
 
-	ghGot(url, opts, function (err, data, res) {
-		if (err) {
-			cb(err);
-			return;
-		}
+	(function loop() {
+		var url = 'users/' + user + '/repos?&per_page=100&page=' + page;
 
-		ret = ret.concat(data);
+		ghGot(url, opts, function(err, data, res) {
+			if (err) {
+				cb(err);
+				return;
+			}
 
-		if (res.headers.link && res.headers.link.indexOf('next') !== -1) {
-			page++;
-			getRepos(user, opts, cb);
-			return;
-		}
+			ret = ret.concat(data);
 
-		cb(null, ret);
-	});
+			if (res.headers.link && res.headers.link.indexOf('next') !== -1) {
+				page++;
+				loop();
+				return;
+			}
+
+			cb(null, ret);
+		});
+	}());
+
 }
 
 module.exports = function (user, opts, cb) {

--- a/test.js
+++ b/test.js
@@ -22,3 +22,18 @@ test('user with lower than 100 repos', function (t) {
 		t.assert(data.length, data.length);
 	});
 });
+
+test('two requests should return same data', function (t) {
+	t.plan(5);
+	var token = '523ef691191741c99d5afbcfe58079bfa0038771';
+
+	githubRepos('octocat', {token: token}, function (err, data1) {
+		t.assert(!err, err);
+		t.assert(data1.length, data1.length);
+		githubRepos('octocat', {token: token}, function (err, data2) {
+		t.assert(!err, err);
+			t.assert(data2.length, data2.length);
+			t.assert(data1.length === data2.length);
+		});
+	});
+});


### PR DESCRIPTION
Currently state is being shared between multiple async calls, causing results to be indefinitely concated together.

I've added a failing test and then removed the global state, fixing the test.
