### PR TITLE
Add `repos` and `urls` to the list of boolean CLI flags

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,9 @@ var cli = meow([
 ], {
 	boolean: [
 		'forks',
-		'sources'
+		'repos',
+		'sources',
+		'urls'
 	],
 	string: [
 		'token'


### PR DESCRIPTION
This patch makes `--repos` and `--urls` boolean-valued, so that minimist doesn't treat the succeeding token as a value.

Example:

```
$ github-repositories -sr eush77
User required
```

What happened is that minimist parsed the command line into the following structure:

``` js
{ forks: false,
  f: false,
  sources: true,
  s: true,
  r: 'eush77',
  repos: 'eush77' }
```

It should rather be `{ repos: true }`. This is what this patch is fixing.
