### PR TITLE
Added object type to options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,11 @@ Username to fetch repos from.
 
 #### options
 
+Type: `object`
+
 ##### token
 
+Name: `token`
 Type: `string`
 
 Token to authenticate with. Use this to increase the request count. Github supports


### PR DESCRIPTION
Not realizing that token needed to be in an `{token: 'string}` form threw me. This should help.