### PR TITLE
Add support for organizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "gh-got": "^3.0.0",
+    "is-github-user-or-org": "^1.0.0",
     "meow": "^3.3.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -9,6 +9,13 @@ test('user with more than 100 repos', async t => {
 	t.true(repos.length > 100);
 });
 
+test('organization using organization api', async t => {
+	const token = '523ef691191741c99d5afbcfe58079bfa0038771';
+	const repos = await m('OpenSourceDesign', {token});
+
+	t.truthy(repos.length);
+});
+
 test('user with lower than 100 repos', async t => {
 	const token = '523ef691191741c99d5afbcfe58079bfa0038771';
 	const repos = await m('octocat', {token});

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('user with more than 100 repos', async t => {
 
 test('organization using organization api', async t => {
 	const token = '523ef691191741c99d5afbcfe58079bfa0038771';
-	const repos = await m('OpenSourceDesign', {token});
+	const repos = await m('github', {token});
 
 	t.truthy(repos.length);
 });


### PR DESCRIPTION
There is an issue currently where private repositories from an organization are not available through the users/ endpoint. This check fixes that by first getting the type of the user requested, and udpating the request appropriately.