### PR TITLE
feat: Add a short help option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,7 +31,8 @@ const cli = meow(`
 		r: 'repos',
 		s: 'sources',
 		t: 'token',
-		u: 'urls'
+		u: 'urls',
+		v: 'version'
 	}
 });
 

--- a/cli.js
+++ b/cli.js
@@ -26,6 +26,7 @@ const cli = meow(`
 		'token'
 	],
 	alias: {
+		h: 'help',
 		f: 'forks',
 		r: 'repos',
 		s: 'sources',


### PR DESCRIPTION
Right now, `-h` causes an error saying "User required." Adding an alias makes it default to showing the help option.